### PR TITLE
refactor!: change key bindings for split pane resizing

### DIFF
--- a/internal/app/task_test.go
+++ b/internal/app/task_test.go
@@ -8,6 +8,44 @@ import (
 	"github.com/leg100/pug/internal"
 )
 
+func TestTaskList_Split(t *testing.T) {
+	t.Parallel()
+
+	tm := setupAndInitModule(t)
+
+	// Go to task list
+	tm.Type("t")
+
+	// Expect tasks that are automatically triggered when a module is loaded
+	waitFor(t, tm, func(s string) bool {
+		return strings.Contains(s, "Tasks") &&
+			strings.Contains(s, "1-5 of 5") &&
+			matchPattern(t, `modules/a.*init.*exited`, s) &&
+			matchPattern(t, `modules/a.*workspace list.*exited`, s) &&
+			matchPattern(t, `modules/a.*default.*state pull.*exited`, s)
+	})
+
+	// Shrink the split until only 3 tasks are visible. By default, the split
+	// view shows 12 rows of tasks. Therefore, the pane needs to be decreased in
+	// height 9 times.
+	tm.Type(strings.Repeat("-", 9))
+
+	waitFor(t, tm, func(s string) bool {
+		return strings.Contains(s, "Tasks") &&
+			strings.Contains(s, "1-3 of 5")
+	})
+
+	// Increase the split until all 5 tasks are visible. That means the split
+	// needs to be increased 2 times.
+	tm.Type(strings.Repeat("+", 2))
+
+	waitFor(t, tm, func(s string) bool {
+		return strings.Contains(s, "Tasks") &&
+			strings.Contains(s, "1-5 of 5")
+	})
+
+}
+
 func TestTask_SingleApply(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/split/keys.go
+++ b/internal/tui/split/keys.go
@@ -3,22 +3,22 @@ package split
 import "github.com/charmbracelet/bubbles/key"
 
 type keyMap struct {
-	TogglePreview key.Binding
-	GrowPreview   key.Binding
-	ShrinkPreview key.Binding
+	ToggleSplit   key.Binding
+	IncreaseSplit key.Binding
+	DecreaseSplit key.Binding
 }
 
 var Keys = keyMap{
-	TogglePreview: key.NewBinding(
-		key.WithKeys("P"),
-		key.WithHelp("P", "toggle preview"),
+	ToggleSplit: key.NewBinding(
+		key.WithKeys("S"),
+		key.WithHelp("S", "toggle split"),
 	),
-	GrowPreview: key.NewBinding(
-		key.WithKeys("+"),
-		key.WithHelp("+", "grow preview"),
-	),
-	ShrinkPreview: key.NewBinding(
+	DecreaseSplit: key.NewBinding(
 		key.WithKeys("-"),
-		key.WithHelp("-", "shrink preview"),
+		key.WithHelp("-", "decrease split"),
+	),
+	IncreaseSplit: key.NewBinding(
+		key.WithKeys("+"),
+		key.WithHelp("+", "increase split"),
 	),
 }

--- a/internal/tui/split/model.go
+++ b/internal/tui/split/model.go
@@ -13,12 +13,12 @@ import (
 )
 
 const (
-	// default height of the top list pane, not including borders
+	// default height of the top list pane, including borders
 	defaultListPaneHeight = 15
 	// previewVisibleDefault sets the default visibility for the preview pane.
 	previewVisibleDefault = true
 	// minimum height of the list pane inc. borders.
-	minListPaneHeight = 4
+	minListPaneHeight = table.MinHeight
 	// minimum height of the preview pane inc. borders.
 	minPreviewPaneHeight = 3
 )

--- a/internal/tui/table/table.go
+++ b/internal/tui/table/table.go
@@ -164,8 +164,7 @@ func (m *Model[V]) setDimensions(width, height int) {
 		m.viewport.Height = max(0, m.viewport.Height-filterHeight)
 	}
 
-	// Set available width for table to expand into, whilst respecting a
-	// minimum width of 80, and accomodating border.
+	// Set available width for table to expand into, accomodating border.
 	m.viewport.Width = max(0, width-2)
 	m.recalculateWidth()
 
@@ -522,17 +521,17 @@ func (m *Model[V]) SetItems(items map[resource.ID]V) {
 			// the user edits the filter value, particularly as the row renderer
 			// can make data lookups on each invocation. But there is no obvious
 			// alternative at present.
-			filterMatch := func(v V) bool {
-				for _, v := range m.rowRenderer(it) {
+			filterMatch := func() bool {
+				for _, row := range m.rowRenderer(it) {
 					// Remove ANSI escapes code before filtering
-					v = internal.StripAnsi(v)
-					if strings.Contains(v, m.filter.Value()) {
+					row = internal.StripAnsi(row)
+					if strings.Contains(row, m.filter.Value()) {
 						return true
 					}
 				}
 				return false
 			}
-			if !filterMatch(it) {
+			if !filterMatch() {
 				// Skip item not matching filter
 				continue
 			}

--- a/internal/tui/table/table.go
+++ b/internal/tui/table/table.go
@@ -26,6 +26,9 @@ const (
 	headerHeight = 1
 	// Height of filter widget
 	filterHeight = 2
+	// Minimum recommended height for the table widget. Respecting this minimum
+	// ensures the header and the borders and the filter widget are visible.
+	MinHeight = 6
 )
 
 // Model defines a state for the table widget.
@@ -476,11 +479,7 @@ func (m Model[V]) RowInfo() string {
 	top := m.start + 1
 	bottom := m.start + m.viewport.VisibleLineCount()
 
-	// Only print range of rows if there are any rows
-	var prefix string
-	if (bottom - top) > 0 {
-		prefix = fmt.Sprintf("%d-%d of ", top, bottom)
-	}
+	prefix := fmt.Sprintf("%d-%d of ", top, bottom)
 
 	if m.filterVisible() {
 		return prefix + fmt.Sprintf("%d/%d", len(m.rows), len(m.items))

--- a/internal/tui/task/group.go
+++ b/internal/tui/task/group.go
@@ -4,10 +4,13 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/leg100/pug/internal/resource"
 	"github.com/leg100/pug/internal/task"
 	"github.com/leg100/pug/internal/tui"
+	"github.com/leg100/pug/internal/tui/keys"
+	"github.com/leg100/pug/internal/tui/split"
 	"github.com/leg100/pug/internal/tui/table"
 )
 
@@ -123,4 +126,14 @@ func (m groupModel) Title() string {
 
 func (m groupModel) Status() string {
 	return m.helpers.GroupReport(m.group, false)
+}
+
+func (m groupModel) HelpBindings() []key.Binding {
+	bindings := []key.Binding{
+		keys.Common.Cancel,
+		keys.Common.Apply,
+		keys.Common.State,
+		keys.Common.Retry,
+	}
+	return append(bindings, keys.KeyMapToSlice(split.Keys)...)
 }

--- a/internal/tui/top/model.go
+++ b/internal/tui/top/model.go
@@ -27,6 +27,9 @@ const (
 	normalMode mode = iota // default
 	promptMode             // confirm prompt is visible and taking input
 	filterMode             // filter is visible and taking input
+
+	// minimum height of view area.
+	minViewHeight = 10
 )
 
 type model struct {
@@ -382,6 +385,8 @@ func (m model) View() string {
 
 // viewHeight returns the height available to the current model (subordinate to
 // the top model).
+//
+// TODO: rename contentHeight
 func (m model) viewHeight() int {
 	vh := m.height - breadcrumbsHeight - messageFooterHeight
 	if m.mode == promptMode {
@@ -390,10 +395,12 @@ func (m model) viewHeight() int {
 	if m.showHelp {
 		vh -= helpWidgetHeight
 	}
-	return vh
+	return max(minViewHeight, vh)
 }
 
 // viewWidth retrieves the width available within the main view
+//
+// TODO: rename contentWidth
 func (m model) viewWidth() int {
 	return m.width
 }


### PR DESCRIPTION
* Update the key binding for toggling the split pane from `P` to `S`.
* Swap the behaviour of the `-` and `+` keys to resize the split in a more intuitive manner.
* Improve sanity checking of split resizing to ensure it cannot go below or beyond terminal height.
