### PR TITLE
feat: switch to using serials for IDs

### DIFF
--- a/internal/app/helpers_test.go
+++ b/internal/app/helpers_test.go
@@ -79,7 +79,7 @@ func setup(t *testing.T, workdir string, opts ...configOption) *testModel {
 	tm := teatest.NewTestModel(
 		t,
 		app.model,
-		teatest.WithInitialTermSize(100, 50),
+		teatest.WithInitialTermSize(120, 50),
 	)
 	t.Cleanup(func() {
 		tm.Quit()

--- a/internal/app/task_test.go
+++ b/internal/app/task_test.go
@@ -24,6 +24,7 @@ func TestTaskList_Split(t *testing.T) {
 
 	// Expect tasks that are automatically triggered when a module is loaded
 	waitFor(t, tm, func(s string) bool {
+		t.Log(s)
 		return strings.Contains(s, "Tasks") &&
 			strings.Contains(s, "1-4 of 4") &&
 			matchPattern(t, `modules/a.*init.*exited`, s) &&

--- a/internal/app/task_test.go
+++ b/internal/app/task_test.go
@@ -24,7 +24,6 @@ func TestTaskList_Split(t *testing.T) {
 
 	// Expect tasks that are automatically triggered when a module is loaded
 	waitFor(t, tm, func(s string) bool {
-		t.Log(s)
 		return strings.Contains(s, "Tasks") &&
 			strings.Contains(s, "1-4 of 4") &&
 			matchPattern(t, `modules/a.*init.*exited`, s) &&

--- a/internal/logging/message.go
+++ b/internal/logging/message.go
@@ -8,19 +8,15 @@ import (
 
 // Message is the event payload for a log message
 type Message struct {
-	Time       time.Time
-	Level      string
-	Message    string `json:"msg"`
-	Attributes []Attr
-
-	// Serial uniquely identifies the message (within the scope of the logger it
-	// was emitted from). The higher the Serial number the newer the message.
-	Serial uint
-
 	// A message is a pug resource, but only insofar as it makes it easier to
 	// handle consistently alongside all other resources (modules, workspaces,
 	// etc) in the TUI.
 	resource.Common
+
+	Time       time.Time
+	Level      string
+	Message    string `json:"msg"`
+	Attributes []Attr
 }
 
 type Attr struct {

--- a/internal/logging/writer.go
+++ b/internal/logging/writer.go
@@ -12,15 +12,13 @@ import (
 // writer is a slog TextHandler writer that both keeps the log records in
 // memory and emits and them as pug events.
 type writer struct {
-	table  *resource.Table[Message]
-	serial uint
+	table *resource.Table[Message]
 }
 
 func (w *writer) Write(p []byte) (int, error) {
 	d := logfmt.NewDecoder(bytes.NewReader(p))
 	for d.ScanRecord() {
 		msg := Message{
-			Serial: w.serial,
 			Common: resource.New(resource.Log, resource.GlobalResource),
 		}
 		for d.ScanKeyval() {
@@ -43,7 +41,6 @@ func (w *writer) Write(p []byte) (int, error) {
 			}
 		}
 		w.table.Add(msg.ID, msg)
-		w.serial++
 	}
 	if d.Err() != nil {
 		return 0, d.Err()

--- a/internal/resource/id_test.go
+++ b/internal/resource/id_test.go
@@ -1,0 +1,22 @@
+package resource
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestID_String(t *testing.T) {
+	mod := NewID(Module)
+	ws := NewID(Workspace)
+	run := NewID(Run)
+	task := NewID(Task)
+
+	t.Run("string", func(t *testing.T) {
+		assert.True(t, strings.HasPrefix(mod.String(), "#"))
+		assert.True(t, strings.HasPrefix(ws.String(), "#"))
+		assert.True(t, strings.HasPrefix(run.String(), "#"))
+		assert.True(t, strings.HasPrefix(task.String(), "#"))
+	})
+}

--- a/internal/resource/resource_test.go
+++ b/internal/resource/resource_test.go
@@ -1,7 +1,6 @@
 package resource
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,13 +11,6 @@ func TestResource(t *testing.T) {
 	ws := New(Workspace, mod)
 	run := New(Run, ws)
 	task := New(Task, run)
-
-	t.Run("string", func(t *testing.T) {
-		assert.True(t, strings.HasPrefix(mod.String(), "mod-"))
-		assert.True(t, strings.HasPrefix(ws.String(), "ws-"))
-		assert.True(t, strings.HasPrefix(run.String(), "run-"))
-		assert.True(t, strings.HasPrefix(task.String(), "task-"))
-	})
 
 	t.Run("has ancestor", func(t *testing.T) {
 		assert.True(t, task.HasAncestor(mod.ID))

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -83,7 +83,6 @@ func newState(ws resource.Resource, r io.Reader) (*State, error) {
 func (s *State) LogValue() slog.Value {
 	return slog.GroupValue(
 		slog.Int("resources", len(s.Resources)),
-		slog.Any("workspace", s.WorkspaceID),
 		slog.Int64("serial", s.Serial),
 	)
 }

--- a/internal/tui/table/columns.go
+++ b/internal/tui/table/columns.go
@@ -1,16 +1,10 @@
 package table
 
 import (
-	"github.com/leg100/pug/internal/resource"
 	"github.com/leg100/pug/internal/run"
 )
 
 var (
-	IDColumn = Column{
-		Key:   "id",
-		Title: "ID", Width: resource.IDEncodedMaxLen,
-		FlexFactor: 1,
-	}
 	ModuleColumn = Column{
 		Key:            "module",
 		Title:          "MODULE",
@@ -20,18 +14,6 @@ var (
 	WorkspaceColumn = Column{
 		Key:        "workspace",
 		Title:      "WORKSPACE",
-		FlexFactor: 1,
-	}
-	RunColumn = Column{
-		Key:        "run",
-		Title:      "RUN",
-		Width:      resource.IDEncodedMaxLen,
-		FlexFactor: 1,
-	}
-	TaskColumn = Column{
-		Key:        "task",
-		Title:      "TASK",
-		Width:      resource.IDEncodedMaxLen,
 		FlexFactor: 1,
 	}
 	RunStatusColumn = Column{

--- a/internal/tui/task/group_list.go
+++ b/internal/tui/task/group_list.go
@@ -21,7 +21,7 @@ var (
 	taskGroupID = table.Column{
 		Key:   "task_group_id",
 		Title: "TASK GROUP ID",
-		Width: resource.IDEncodedMaxLen,
+		Width: len("TASK GROUP ID"),
 	}
 )
 
@@ -32,8 +32,8 @@ type GroupListMaker struct {
 
 func (m *GroupListMaker) Make(_ resource.ID, width, height int) (tea.Model, error) {
 	columns := []table.Column{
-		commandColumn,
 		taskGroupID,
+		commandColumn,
 		taskGroupCount,
 		ageColumn,
 	}

--- a/internal/tui/task/list.go
+++ b/internal/tui/task/list.go
@@ -17,6 +17,11 @@ import (
 )
 
 var (
+	taskIDColumn = table.Column{
+		Key:   "task_id",
+		Title: "TASK ID",
+		Width: len("TASK_ID"),
+	}
 	commandColumn = table.Column{
 		Key:        "command",
 		Title:      "COMMAND",
@@ -68,6 +73,7 @@ type ListMaker struct {
 
 func (mm *ListMaker) Make(_ resource.ID, width, height int) (tea.Model, error) {
 	columns := []table.Column{
+		taskIDColumn,
 		table.ModuleColumn,
 		table.WorkspaceColumn,
 		commandColumn,
@@ -78,11 +84,11 @@ func (mm *ListMaker) Make(_ resource.ID, width, height int) (tea.Model, error) {
 
 	renderer := func(t *task.Task) table.RenderedRow {
 		row := table.RenderedRow{
+			taskIDColumn.Key:          t.ID.String(),
 			table.ModuleColumn.Key:    mm.Helpers.ModulePath(t),
 			table.WorkspaceColumn.Key: mm.Helpers.WorkspaceName(t),
 			commandColumn.Key:         t.CommandString(),
 			ageColumn.Key:             tui.Ago(time.Now(), t.Updated),
-			table.IDColumn.Key:        t.String(),
 			statusColumn.Key:          mm.Helpers.TaskStatus(t, false),
 		}
 


### PR DESCRIPTION
For resource IDs, switch from using base58 encoded UUIDs to more concise zero-based serial numbers.