### PR TITLE
fix: make stdout available separate from stderr

### DIFF
--- a/internal/app/helpers_test.go
+++ b/internal/app/helpers_test.go
@@ -24,7 +24,13 @@ type configOption func(cfg *config)
 func withTerragrunt() configOption {
 	return func(cfg *config) {
 		cfg.Program = "terragrunt"
-		cfg.Args = []string{"--terragrunt-tfpath", "terraform"}
+		// Use terraform to ensure the provider mirror is valid (terraform and
+		// tofu use different registry hosts, which forms part of the provider
+		// mirror path).
+		// And disable auto-init otherwise multiple init's may be running
+		// concurrently, which causes issues when writing the provider lock
+		// file.
+		cfg.Args = []string{"--terragrunt-tfpath", "terraform", "--terragrunt-no-auto-init"}
 		cfg.Terragrunt = true
 	}
 }

--- a/internal/app/terragrunt_test.go
+++ b/internal/app/terragrunt_test.go
@@ -182,7 +182,8 @@ func setupAndInitTerragruntModulesWithDependencies(t *testing.T) *testModel {
 			matchPattern(t, `modules/mysql.*modules/vpc`, s) &&
 			matchPattern(t, "modules/redis.*modules/vpc", s) &&
 			strings.Contains(s, "modules/backend-app") &&
-			strings.Contains(s, "modules/frontend-app")
+			strings.Contains(s, "modules/frontend-app") &&
+			matchPattern(t, `\..*local.*default`, s)
 	})
 
 	// Select all modules and init
@@ -190,11 +191,12 @@ func setupAndInitTerragruntModulesWithDependencies(t *testing.T) *testModel {
 	tm.Type("i")
 	waitFor(t, tm, func(s string) bool {
 		return matchPattern(t, "TaskGroup.*init", s) &&
-			matchPattern(t, `modules/vpc.*exited`, s) &&
-			matchPattern(t, `modules/redis.*exited`, s) &&
-			matchPattern(t, `modules/mysql.*exited`, s) &&
-			matchPattern(t, `modules/frontend-app.*exited`, s) &&
-			matchPattern(t, `modules/backend-app.*exited`, s)
+			matchPattern(t, `modules/vpc.*init.*exited`, s) &&
+			matchPattern(t, `modules/redis.*init.*exited`, s) &&
+			matchPattern(t, `modules/mysql.*init.*exited`, s) &&
+			matchPattern(t, `modules/frontend-app.*init.*exited`, s) &&
+			matchPattern(t, `modules/backend-app.*init.*exited`, s) &&
+			matchPattern(t, `\..*init.*exited`, s)
 	})
 
 	// Go back to modules listing
@@ -206,7 +208,8 @@ func setupAndInitTerragruntModulesWithDependencies(t *testing.T) *testModel {
 			matchPattern(t, `modules/mysql.*default`, s) &&
 			matchPattern(t, "modules/redis.*default", s) &&
 			matchPattern(t, "modules/backend-app.*default", s) &&
-			matchPattern(t, "modules/frontend-app.*default", s)
+			matchPattern(t, "modules/frontend-app.*default", s) &&
+			matchPattern(t, `\..*local.*default`, s)
 	})
 
 	// Clear selection

--- a/internal/module/service.go
+++ b/internal/module/service.go
@@ -119,7 +119,7 @@ func (s *Service) loadTerragruntDependencies() error {
 	if err != nil {
 		return err
 	}
-	return s.loadTerragruntDependenciesFromDigraph(task.NewReader())
+	return s.loadTerragruntDependenciesFromDigraph(task.NewReader(false))
 }
 
 func (s *Service) loadTerragruntDependenciesFromDigraph(r io.Reader) error {

--- a/internal/run/service.go
+++ b/internal/run/service.go
@@ -103,7 +103,7 @@ func (s *Service) plan(workspaceID resource.ID, opts CreateOptions) (*task.Task,
 			run.updateStatus(Canceled)
 		},
 		AfterExited: func(t *task.Task) {
-			if err := run.finishPlan(t.NewReader()); err != nil {
+			if err := run.finishPlan(t.NewReader(false)); err != nil {
 				s.logger.Error("finishing plan", "error", err, "run", run)
 			}
 		},
@@ -199,7 +199,7 @@ func (s *Service) createApplySpec(id resource.ID, opts *CreateOptions) (task.Cre
 			run.updateStatus(Canceled)
 		},
 		AfterExited: func(t *task.Task) {
-			if err := run.finishApply(t.NewReader()); err != nil {
+			if err := run.finishApply(t.NewReader(false)); err != nil {
 				s.logger.Error("finishing apply", "error", err, "run", run)
 				return
 			}

--- a/internal/state/service.go
+++ b/internal/state/service.go
@@ -77,7 +77,7 @@ func (s *Service) Reload(workspaceID resource.ID) (*task.Task, error) {
 		Command: []string{"state", "pull"},
 		JSON:    true,
 		AfterExited: func(t *task.Task) {
-			state, err := newState(t.Workspace(), t.NewReader())
+			state, err := newState(t.Workspace(), t.NewReader(false))
 			if err != nil {
 				s.logger.Error("reloading state", "error", err, "workspace", t.Workspace())
 				return

--- a/internal/task/enqueuer.go
+++ b/internal/task/enqueuer.go
@@ -90,7 +90,7 @@ func (e *enqueuer) enqueueDependentTask(t *Task) bool {
 		case Canceled, Errored:
 			// Dependency failed so mark task as failed too by cancelling it
 			// along with a reason why it was canceled.
-			t.buf.Write([]byte("task dependency failed"))
+			t.stdout.Write([]byte("task dependency failed"))
 			t.updateState(Canceled)
 			return false
 		default:

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -1,7 +1,6 @@
 package task
 
 import (
-	"bufio"
 	"context"
 	"io"
 	"testing"
@@ -12,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTask_stdout(t *testing.T) {
+func TestTask_NewReader(t *testing.T) {
 	t.Parallel()
 
 	f := factory{
@@ -26,20 +25,24 @@ func TestTask_stdout(t *testing.T) {
 	require.NoError(t, err)
 	waitfn()
 
-	scanner := bufio.NewScanner(task.NewReader())
-	want := []string{"foo", "bar", "baz", "bye"}
-	for i := 0; scanner.Scan(); i++ {
-		assert.Equal(t, want[i], scanner.Text())
-	}
-	require.NoError(t, scanner.Err())
-	assert.NoError(t, task.Err)
-	assert.Equal(t, Exited, task.State)
+	got, err := io.ReadAll(task.NewReader(false))
+	require.NoError(t, err)
+	assert.Equal(t, "foo\nbar\nbaz\nbye\n", string(got))
 
 	// create another reader, to demonstrate that reading resets to the
 	// beginning
-	got, err := io.ReadAll(task.NewReader())
+	got, err = io.ReadAll(task.NewReader(false))
 	require.NoError(t, err)
 	assert.Equal(t, "foo\nbar\nbaz\nbye\n", string(got))
+
+	// this time, create a combined reader, to demonstrate reading both stdout
+	// and stderr
+	got, err = io.ReadAll(task.NewReader(true))
+	require.NoError(t, err)
+	// stderr and stdout streams can be interwoven, so we use assert.Contains
+	// rather than assert.Equal
+	assert.Contains(t, string(got), "foo\nbar\nbaz\nbye\n")
+	assert.Contains(t, string(got), "err")
 }
 
 func TestTask_cancel(t *testing.T) {
@@ -61,7 +64,7 @@ func TestTask_cancel(t *testing.T) {
 		done <- struct{}{}
 	}()
 
-	assert.Equal(t, "ok, you can kill me now\n", <-iochan.DelimReader(task.NewReader(), '\n'))
+	assert.Equal(t, "ok, you can kill me now\n", <-iochan.DelimReader(task.NewReader(false), '\n'))
 	task.cancel()
 	<-done
 	assert.NoError(t, task.Err)

--- a/internal/task/testdata/task
+++ b/internal/task/testdata/task
@@ -4,3 +4,4 @@ echo foo
 echo bar
 echo baz
 echo bye
+>&2 echo err

--- a/internal/tui/task/model.go
+++ b/internal/tui/task/model.go
@@ -48,7 +48,7 @@ func (mm *Maker) make(id resource.ID, width, height int, border bool) (tea.Model
 		tasks:   mm.Tasks,
 		runs:    mm.Runs,
 		task:    task,
-		output:  task.NewReader(),
+		output:  task.NewReader(true),
 		spinner: mm.Spinner,
 		// read upto 1kb at a time
 		buf:      make([]byte, 1024),

--- a/internal/tui/viewport.go
+++ b/internal/tui/viewport.go
@@ -107,7 +107,7 @@ func (m *Viewport) SetDimensions(width, height int) {
 	}
 }
 
-func (m *Viewport) AppendContent(content string, finished bool) error {
+func (m *Viewport) AppendContent(content string, finished bool) (err error) {
 	m.content += content
 	if finished {
 		if m.content == "" {
@@ -119,8 +119,10 @@ func (m *Viewport) AppendContent(content string, finished bool) error {
 			//
 			// TODO: avoid casting to string and back, thereby avoiding
 			// unnecessary allocations.
-			if b, err := prettyjson.Format([]byte(m.content)); err != nil {
-				return fmt.Errorf("pretty printing json content: %w", err)
+			if b, fmterr := prettyjson.Format([]byte(m.content)); fmterr != nil {
+				// In the event of an error, still set unprettified content
+				// below.
+				err = fmt.Errorf("pretty printing json content: %w", fmterr)
 			} else {
 				m.content = string(b)
 			}
@@ -130,7 +132,7 @@ func (m *Viewport) AppendContent(content string, finished bool) error {
 	if m.Autoscroll {
 		m.viewport.GotoBottom()
 	}
-	return nil
+	return err
 }
 
 func (m *Viewport) setContent() {


### PR DESCRIPTION
Makes it possible to read only the stdout from a task, filtering out stderr which may contain logs. This is useful for certain tasks that parse the output of `terraform workspace list` and `terraform state pull`.

Whereas the user expects to still see both stdout and stderr in the TUI, which remains the case.