### PR TITLE
fix: detect terragrunt modules without `remote_state` block

### DIFF
--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -104,7 +104,7 @@ func findModules(logger logging.Interface, workdir internal.Workdir) (modules []
 				// type (not unless it evaluates terragrunt's language and
 				// follows `find_in_parent` etc. to locate the effective
 				// remote_state, which is perhaps a future exercise...).
-				logger.Warn("reloading modules: could not determine backend type", "path", path, "error", err)
+				logger.Warn("reloading modules: could not determine backend type", "path", path)
 			}
 			// Strip workdir from module path
 			stripped, err := filepath.Rel(workdir.String(), filepath.Dir(path))

--- a/internal/module/module_test.go
+++ b/internal/module/module_test.go
@@ -24,10 +24,11 @@ func TestFindModules(t *testing.T) {
 	got, err := findModules(logging.Discard, workdir)
 	require.NoError(t, err)
 
-	assert.Equal(t, 4, len(got), got)
+	assert.Equal(t, 5, len(got), got)
 	assert.Contains(t, got, Options{Path: "with_local_backend", Backend: "local"})
 	assert.Contains(t, got, Options{Path: "with_s3_backend", Backend: "s3"})
 	assert.Contains(t, got, Options{Path: "with_cloud_backend", Backend: "cloud"})
 	assert.Contains(t, got, Options{Path: "terragrunt_with_local", Backend: "local"})
+	assert.Contains(t, got, Options{Path: "terragrunt_without_backend", Backend: ""})
 	assert.NotContains(t, got, "broken")
 }

--- a/internal/module/testdata/modules/terragrunt_without_backend/terragrunt.hcl
+++ b/internal/module/testdata/modules/terragrunt_without_backend/terragrunt.hcl
@@ -1,0 +1,3 @@
+include {
+  path = find_in_parent_folders("root.hcl")
+}


### PR DESCRIPTION
Fixes #107 