### PR TITLE
feat!: standardize navigation keys and change untaint key

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Press `s` to go to the state page, listing a workspace's resources.
 |`D`|Run `terraform state rm`|&check;|
 |`M`|Run `terraform state mv`|&cross;|
 |`Ctrl+t`|Run `terraform taint`|&check;|
-|`Ctrl+u`|Run `terraform untaint`|&check;|
+|`U`|Run `terraform untaint`|&check;|
 |`Ctrl+r`|Run `terraform state pull`|-|
 
 ### Tasks
@@ -249,8 +249,10 @@ Common vim key bindings are supported for navigation.
 |--|--|
 |`Up/k`|Up one row|
 |`Down/j`|Down one row|
-|`PgUp/b`|Up one page|
-|`PgDown/f`|Down one page|
+|`PgUp`|Up one page|
+|`PgDown`|Down one page|
+|`Ctrl+u`|Up half page|
+|`Ctrl+d`|Down half page|
 |`Home/g`|Go to top|
 |`End/G`|Go to bottom|
 

--- a/demo/vhs.tape
+++ b/demo/vhs.tape
@@ -119,7 +119,7 @@ Escape Sleep 0.5s
 # select all resources
 Ctrl+a Sleep 0.5s
 # taint all resources
-Ctrl+u
+Type "U"
 # we're taken to the untaint task group page
 Sleep 0.5s
 # preview output for several tasks

--- a/internal/app/state_test.go
+++ b/internal/app/state_test.go
@@ -33,7 +33,7 @@ func TestState_SingleTaint_Untaint(t *testing.T) {
 	})
 
 	// Untaint resource
-	tm.Send(tea.KeyMsg{Type: tea.KeyCtrlU})
+	tm.Type("U")
 
 	// Expect to be taken to task page for untaint
 	waitFor(t, tm, func(s string) bool {
@@ -81,7 +81,7 @@ func TestState_MultipleTaint_Untaint(t *testing.T) {
 	// Untaint all resources (need to select all again, because resources have
 	// been reloaded).
 	tm.Send(tea.KeyMsg{Type: tea.KeyCtrlA})
-	tm.Send(tea.KeyMsg{Type: tea.KeyCtrlU})
+	tm.Type("U")
 
 	// Expect to be taken to task group page for untaint
 	waitFor(t, tm, func(s string) bool {

--- a/internal/tui/keys/navigation.go
+++ b/internal/tui/keys/navigation.go
@@ -5,12 +5,14 @@ import (
 )
 
 type navigation struct {
-	LineUp     key.Binding
-	LineDown   key.Binding
-	PageUp     key.Binding
-	PageDown   key.Binding
-	GotoTop    key.Binding
-	GotoBottom key.Binding
+	LineUp       key.Binding
+	LineDown     key.Binding
+	PageUp       key.Binding
+	PageDown     key.Binding
+	HalfPageUp   key.Binding
+	HalfPageDown key.Binding
+	GotoTop      key.Binding
+	GotoBottom   key.Binding
 }
 
 // Navigation returns key bindings for navigation.
@@ -24,12 +26,20 @@ var Navigation = navigation{
 		key.WithHelp("↓/j", "down"),
 	),
 	PageUp: key.NewBinding(
-		key.WithKeys("b", "pgup"),
-		key.WithHelp("b/pgup", "page up"),
+		key.WithKeys("pgup"),
+		key.WithHelp("pgup", "page up"),
 	),
 	PageDown: key.NewBinding(
-		key.WithKeys("f", "pgdown"),
-		key.WithHelp("f/pgdn", "page down"),
+		key.WithKeys("pgdown"),
+		key.WithHelp("pgdn", "page down"),
+	),
+	HalfPageUp: key.NewBinding(
+		key.WithKeys("ctrl+u"),
+		key.WithHelp("ctrl+u", "½ page up"),
+	),
+	HalfPageDown: key.NewBinding(
+		key.WithKeys("ctrl+d"),
+		key.WithHelp("ctrl+d", "½ page down"),
 	),
 	GotoTop: key.NewBinding(
 		key.WithKeys("home", "g"),

--- a/internal/tui/table/table.go
+++ b/internal/tui/table/table.go
@@ -188,6 +188,10 @@ func (m Model[V]) Update(msg tea.Msg) (Model[V], tea.Cmd) {
 			m.MoveUp(m.viewport.Height)
 		case key.Matches(msg, keys.Navigation.PageDown):
 			m.MoveDown(m.viewport.Height)
+		case key.Matches(msg, keys.Navigation.HalfPageUp):
+			m.MoveUp(m.viewport.Height / 2)
+		case key.Matches(msg, keys.Navigation.HalfPageDown):
+			m.MoveDown(m.viewport.Height / 2)
 		case key.Matches(msg, keys.Navigation.GotoTop):
 			m.GotoTop()
 		case key.Matches(msg, keys.Navigation.GotoBottom):

--- a/internal/tui/viewport.go
+++ b/internal/tui/viewport.go
@@ -3,11 +3,13 @@ package tui
 import (
 	"fmt"
 
+	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/hokaccha/go-prettyjson"
+	"github.com/leg100/pug/internal/tui/keys"
 	"github.com/leg100/reflow/wrap"
 )
 
@@ -51,6 +53,16 @@ func (m Viewport) Update(msg tea.Msg) (Viewport, tea.Cmd) {
 		cmd  tea.Cmd
 		cmds []tea.Cmd
 	)
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch {
+		case key.Matches(msg, keys.Navigation.GotoTop):
+			m.viewport.SetYOffset(0)
+		case key.Matches(msg, keys.Navigation.GotoBottom):
+			m.viewport.SetYOffset(m.viewport.TotalLineCount())
+		}
+	}
 
 	// Handle keyboard and mouse events in the viewport
 	m.viewport, cmd = m.viewport.Update(msg)

--- a/internal/tui/workspace/keys.go
+++ b/internal/tui/workspace/keys.go
@@ -28,8 +28,8 @@ var resourcesKeys = resourcesKeyMap{
 		key.WithHelp("ctrl+t", "taint"),
 	),
 	Untaint: key.NewBinding(
-		key.WithKeys("ctrl+u"),
-		key.WithHelp("ctrl+u", "untaint"),
+		key.WithKeys("U"),
+		key.WithHelp("U", "untaint"),
 	),
 	Move: key.NewBinding(
 		key.WithKeys("M"),


### PR DESCRIPTION
Standardizes navigation keys for both the table and viewport widgets:

* `g`: Go to top
* `G`: Go to bottom
* `Ctrl+u`: Go up half page
* `Ctrl+d`: Go down half page
* The key to untaint resources has been re-assigned from `Ctrl+u` to `U`.
* `b` no longer goes up a page
* `f` no longer goes down a page

These changes bring Pug more into line with Vim standard navigation keys.