### PR TITLE
feat: always load a default workspace

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -64,6 +64,7 @@ func New(cfg Config) (*App, error) {
 		Modules: modules,
 		Logger:  logger,
 	})
+	modules.WorkspaceLoader = workspaces
 	states := state.NewService(state.ServiceOptions{
 		Modules:    modules,
 		Workspaces: workspaces,
@@ -76,6 +77,7 @@ func New(cfg Config) (*App, error) {
 		Workspaces: workspaces,
 		States:     states,
 		DataDir:    cfg.DataDir,
+		Workdir:    cfg.Workdir,
 		Logger:     logger,
 		Terragrunt: cfg.Terragrunt,
 	})

--- a/internal/integration/task_test.go
+++ b/internal/integration/task_test.go
@@ -25,7 +25,7 @@ func TestTaskList_Split(t *testing.T) {
 	// Expect tasks that are automatically triggered when a module is loaded
 	waitFor(t, tm, func(s string) bool {
 		return strings.Contains(s, "Tasks") &&
-			strings.Contains(s, "1-4 of 4") &&
+			strings.Contains(s, "1-5 of 5") &&
 			matchPattern(t, `modules/a.*init.*exited`, s) &&
 			matchPattern(t, `modules/a.*workspace list.*exited`, s) &&
 			matchPattern(t, `modules/a.*default.*state pull.*exited`, s)
@@ -38,16 +38,16 @@ func TestTaskList_Split(t *testing.T) {
 
 	waitFor(t, tm, func(s string) bool {
 		return strings.Contains(s, "Tasks") &&
-			strings.Contains(s, "1-3 of 4")
+			strings.Contains(s, "1-3 of 5")
 	})
 
-	// Increase the split until all 4 tasks are visible. That means the split
-	// needs to be increased once.
-	tm.Type(strings.Repeat("+", 1))
+	// Increase the split until all 5 tasks are visible. That means the split
+	// needs to be increased twice.
+	tm.Type(strings.Repeat("+", 2))
 
 	waitFor(t, tm, func(s string) bool {
 		return strings.Contains(s, "Tasks") &&
-			strings.Contains(s, "1-4 of 4")
+			strings.Contains(s, "1-5 of 5")
 	})
 
 }

--- a/internal/module/module.go
+++ b/internal/module/module.go
@@ -23,9 +23,7 @@ type Module struct {
 	// Path relative to pug working directory
 	Path string
 	// The module's current workspace.
-	//
-	// TODO: remove pointer
-	CurrentWorkspaceID *resource.ID
+	CurrentWorkspaceID resource.ID
 	// Whether workspaces have been successfully loaded.
 	LoadedWorkspaces bool
 	// The module's backend type
@@ -60,7 +58,7 @@ func (f *factory) newModule(opts Options) (*Module, error) {
 	if err != nil {
 		return nil, err
 	}
-	mod.CurrentWorkspaceID = &currentWorkspaceID
+	mod.CurrentWorkspaceID = currentWorkspaceID
 	return mod, nil
 }
 

--- a/internal/module/module_test.go
+++ b/internal/module/module_test.go
@@ -7,14 +7,16 @@ import (
 
 	"github.com/leg100/pug/internal"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {
 	os.MkdirAll("./testdata/modules/with_both_s3_backend_and_dot_terraform_dir/.terraform", 0o755)
 
-	workdir, _ := internal.NewWorkdir("./testdata/modules")
+	factory := &factory{&fakeWorkspaceLoader{}}
 
-	got := New(workdir, Options{Path: "with_s3_backend", Backend: "s3"})
+	got, err := factory.newModule(Options{Path: "with_s3_backend", Backend: "s3"})
+	require.NoError(t, err)
 	assert.Equal(t, "with_s3_backend", got.Path)
 }
 

--- a/internal/module/service.go
+++ b/internal/module/service.go
@@ -28,12 +28,11 @@ type Service struct {
 }
 
 type ServiceOptions struct {
-	Tasks           *task.Service
-	Workdir         internal.Workdir
-	PluginCache     bool
-	Logger          logging.Interface
-	Terragrunt      bool
-	WorkspaceLoader WorkspaceLoader
+	Tasks       *task.Service
+	Workdir     internal.Workdir
+	PluginCache bool
+	Logger      logging.Interface
+	Terragrunt  bool
 }
 
 type taskCreator interface {
@@ -62,9 +61,7 @@ func NewService(opts ServiceOptions) *Service {
 		pluginCache: opts.PluginCache,
 		logger:      opts.Logger,
 		terragrunt:  opts.Terragrunt,
-		factory: &factory{
-			WorkspaceLoader: opts.WorkspaceLoader,
-		},
+		factory:     &factory{},
 	}
 }
 

--- a/internal/module/service.go
+++ b/internal/module/service.go
@@ -220,14 +220,6 @@ func (s *Service) Init(moduleID resource.ID) (task.Spec, error) {
 		// The terraform plugin cache is not concurrency-safe, so only allow one
 		// init task to run at any given time.
 		Exclusive: s.pluginCache,
-		AfterCreate: func(task *task.Task) {
-			// Trigger a workspace reload if the module doesn't yet have a
-			// current workspace
-			mod := task.Module().(*Module)
-			if mod.CurrentWorkspaceID == nil {
-				s.Publish(resource.UpdatedEvent, mod)
-			}
-		},
 	})
 }
 
@@ -275,7 +267,7 @@ func (s *Service) SetLoadedWorkspaces(moduleID resource.ID) error {
 // SetCurrent sets the current workspace for the module.
 func (s *Service) SetCurrent(moduleID, workspaceID resource.ID) error {
 	_, err := s.table.Update(moduleID, func(existing *Module) error {
-		existing.CurrentWorkspaceID = &workspaceID
+		existing.CurrentWorkspaceID = workspaceID
 		return nil
 	})
 	return err

--- a/internal/module/service_test.go
+++ b/internal/module/service_test.go
@@ -15,11 +15,17 @@ import (
 func TestLoadTerragruntDependenciesFromDigraph(t *testing.T) {
 	// Setup modules and load into table
 	workdir := internal.NewTestWorkdir(t)
-	vpc := New(workdir, Options{Path: "root/vpc"})
-	redis := New(workdir, Options{Path: "root/redis"})
-	mysql := New(workdir, Options{Path: "root/mysql"})
-	frontend := New(workdir, Options{Path: "root/frontend-app"})
-	backend := New(workdir, Options{Path: "root/backend-app"})
+	factory := &factory{&fakeWorkspaceLoader{}}
+	vpc, err := factory.newModule(Options{Path: "root/vpc"})
+	require.NoError(t, err)
+	redis, err := factory.newModule(Options{Path: "root/redis"})
+	require.NoError(t, err)
+	mysql, err := factory.newModule(Options{Path: "root/mysql"})
+	require.NoError(t, err)
+	frontend, err := factory.newModule(Options{Path: "root/frontend-app"})
+	require.NoError(t, err)
+	backend, err := factory.newModule(Options{Path: "root/backend-app"})
+	require.NoError(t, err)
 	svc := &Service{
 		table:   &fakeModuleTable{modules: []*Module{vpc, redis, mysql, backend, frontend}},
 		workdir: workdir,

--- a/internal/module/service_test.go
+++ b/internal/module/service_test.go
@@ -15,17 +15,11 @@ import (
 func TestLoadTerragruntDependenciesFromDigraph(t *testing.T) {
 	// Setup modules and load into table
 	workdir := internal.NewTestWorkdir(t)
-	factory := &factory{&fakeWorkspaceLoader{}}
-	vpc, err := factory.newModule(Options{Path: "root/vpc"})
-	require.NoError(t, err)
-	redis, err := factory.newModule(Options{Path: "root/redis"})
-	require.NoError(t, err)
-	mysql, err := factory.newModule(Options{Path: "root/mysql"})
-	require.NoError(t, err)
-	frontend, err := factory.newModule(Options{Path: "root/frontend-app"})
-	require.NoError(t, err)
-	backend, err := factory.newModule(Options{Path: "root/backend-app"})
-	require.NoError(t, err)
+	vpc := NewTestModule(t, Options{Path: "root/vpc"})
+	redis := NewTestModule(t, Options{Path: "root/redis"})
+	mysql := NewTestModule(t, Options{Path: "root/mysql"})
+	frontend := NewTestModule(t, Options{Path: "root/frontend-app"})
+	backend := NewTestModule(t, Options{Path: "root/backend-app"})
 	svc := &Service{
 		table:   &fakeModuleTable{modules: []*Module{vpc, redis, mysql, backend, frontend}},
 		workdir: workdir,

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/leg100/pug/internal"
 	"github.com/leg100/pug/internal/logging"
 	"github.com/leg100/pug/internal/pubsub"
 	"github.com/leg100/pug/internal/resource"
@@ -45,6 +46,7 @@ type CreateOptions struct {
 
 type factory struct {
 	dataDir    string
+	workdir    internal.Workdir
 	workspaces workspaceGetter
 	broker     *pubsub.Broker[*plan]
 	terragrunt bool
@@ -71,7 +73,7 @@ func (f *factory) newPlan(workspaceID resource.ID, opts CreateOptions) (*plan, e
 	for _, addr := range plan.TargetAddrs {
 		plan.targetArgs = append(plan.targetArgs, fmt.Sprintf("-target=%s", addr))
 	}
-	if fname, ok := ws.VarsFile(); ok {
+	if fname, ok := ws.VarsFile(f.workdir); ok {
 		flag := fmt.Sprintf("-var-file=%s", fname)
 		plan.varsFileArg = &flag
 	}

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -19,8 +19,9 @@ func TestPlan_VarsFile(t *testing.T) {
 	f, mod, ws := setupTest(t)
 
 	// Create a workspace tfvars file for dev
-	os.MkdirAll(mod.FullPath(), 0o755)
-	_, err := os.Create(filepath.Join(mod.FullPath(), "dev.tfvars"))
+	path := f.workdir.Join(mod.Path, "dev.tfvars")
+	os.MkdirAll(filepath.Dir(path), 0o755)
+	_, err := os.Create(path)
 	require.NoError(t, err)
 
 	run, err := f.newPlan(ws.ID, CreateOptions{})
@@ -44,12 +45,13 @@ func setupTest(t *testing.T) (*factory, *module.Module, *workspace.Workspace) {
 	workdir := internal.NewTestWorkdir(t)
 	testutils.ChTempDir(t, workdir.String())
 
-	mod := module.New(workdir, module.Options{Path: "a/b/c"})
+	mod := module.NewTestModule(t, module.Options{Path: "a/b/c"})
 	ws, err := workspace.New(mod, "dev")
 	require.NoError(t, err)
 	factory := factory{
 		workspaces: &fakeWorkspaceGetter{ws: ws},
 		dataDir:    t.TempDir(),
+		workdir:    workdir,
 	}
 	return &factory, mod, ws
 }

--- a/internal/plan/service.go
+++ b/internal/plan/service.go
@@ -3,6 +3,7 @@ package plan
 import (
 	"fmt"
 
+	"github.com/leg100/pug/internal"
 	"github.com/leg100/pug/internal/logging"
 	"github.com/leg100/pug/internal/module"
 	"github.com/leg100/pug/internal/pubsub"
@@ -31,6 +32,7 @@ type ServiceOptions struct {
 	Workspaces *workspace.Service
 	States     *state.Service
 	DataDir    string
+	Workdir    internal.Workdir
 	Logger     logging.Interface
 	Terragrunt bool
 }
@@ -55,6 +57,7 @@ func NewService(opts ServiceOptions) *Service {
 		logger:     opts.Logger,
 		factory: &factory{
 			dataDir:    opts.DataDir,
+			workdir:    opts.Workdir,
 			workspaces: opts.Workspaces,
 			broker:     broker,
 			terragrunt: opts.Terragrunt,

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/leg100/pug/internal"
 	"github.com/leg100/pug/internal/module"
 	"github.com/leg100/pug/internal/workspace"
 	"github.com/stretchr/testify/assert"
@@ -13,7 +12,7 @@ import (
 )
 
 func TestState(t *testing.T) {
-	mod := module.New(internal.NewTestWorkdir(t), module.Options{Path: "a/b/c"})
+	mod := module.NewTestModule(t, module.Options{Path: "a/b/c"})
 	ws, err := workspace.New(mod, "dev")
 	require.NoError(t, err)
 

--- a/internal/tui/module/list.go
+++ b/internal/tui/module/list.go
@@ -7,6 +7,7 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/leg100/pug/internal"
 	"github.com/leg100/pug/internal/module"
 	"github.com/leg100/pug/internal/plan"
 	"github.com/leg100/pug/internal/resource"
@@ -41,7 +42,7 @@ type ListMaker struct {
 	Workspaces *workspace.Service
 	Plans      *plan.Service
 	Spinner    *spinner.Model
-	Workdir    string
+	Workdir    internal.Workdir
 	Helpers    *tui.Helpers
 	Terragrunt bool
 }
@@ -102,7 +103,7 @@ type list struct {
 
 	table   table.Model[*module.Module]
 	spinner *spinner.Model
-	workdir string
+	workdir internal.Workdir
 	helpers *tui.Helpers
 }
 
@@ -133,7 +134,8 @@ func (m list) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, ReloadModules(false, m.Modules)
 		case key.Matches(msg, keys.Common.Edit):
 			if row, ok := m.table.CurrentRow(); ok {
-				return m, tui.OpenEditor(row.Value.FullPath())
+				path := m.workdir.Join(row.Value.Path)
+				return m, tui.OpenEditor(path)
 			}
 		case key.Matches(msg, keys.Common.Init):
 			cmd := m.helpers.CreateTasks(m.Modules.Init, m.table.SelectedOrCurrentIDs()...)

--- a/internal/tui/module/list.go
+++ b/internal/tui/module/list.go
@@ -151,9 +151,7 @@ func (m list) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, cmd
 		case key.Matches(msg, keys.Common.State):
 			if row, ok := m.table.CurrentRow(); ok {
-				if ws := m.helpers.ModuleCurrentWorkspace(row.Value); ws != nil {
-					return m, tui.NavigateTo(tui.ResourceListKind, tui.WithParent(ws))
-				}
+				return m, tui.NavigateTo(tui.ResourceListKind, tui.WithParent(row.Value.CurrentWorkspaceID))
 			}
 		case key.Matches(msg, keys.Common.PlanDestroy):
 			createPlanOpts.Destroy = true

--- a/internal/tui/top/makers.go
+++ b/internal/tui/top/makers.go
@@ -54,7 +54,7 @@ func makeMakers(cfg app.Config, app *app.App, spinner *spinner.Model) map[tui.Ki
 			Workspaces: app.Workspaces,
 			Plans:      app.Plans,
 			Spinner:    spinner,
-			Workdir:    cfg.Workdir.PrettyString(),
+			Workdir:    cfg.Workdir,
 			Helpers:    helpers,
 			Terragrunt: cfg.Terragrunt,
 		},

--- a/internal/workdir.go
+++ b/internal/workdir.go
@@ -43,6 +43,11 @@ func NewWorkdir(path string) (Workdir, error) {
 	return wd, nil
 }
 
+func (wd Workdir) Join(paths ...string) string {
+	paths = append([]string{wd.path}, paths...)
+	return filepath.Join(paths...)
+}
+
 func (wd Workdir) String() string {
 	return wd.path
 }

--- a/internal/workspace/reloader.go
+++ b/internal/workspace/reloader.go
@@ -33,9 +33,20 @@ func (s ReloadSummary) LogValue() slog.Value {
 	)
 }
 
+func (r *reloader) createReloadTask(moduleID resource.ID) error {
+	spec, err := r.Reload(moduleID)
+	if err != nil {
+		return err
+	}
+	_, err = r.tasks.Create(spec)
+	return err
+}
+
 // Reload returns a task spec that runs `terraform workspace list` on a
 // module and updates pug with the results, adding any newly discovered
 // workspaces and pruning any workspaces no longer found to exist.
+//
+// TODO: separate into Load and Reload
 func (r *reloader) Reload(moduleID resource.ID) (task.Spec, error) {
 	mod, err := r.modules.Get(moduleID)
 	if err != nil {
@@ -52,6 +63,9 @@ func (r *reloader) Reload(moduleID resource.ID) (task.Spec, error) {
 			}
 			added, removed, err := r.resetWorkspaces(mod, found, current)
 			if err != nil {
+				return nil, err
+			}
+			if err := r.modules.SetLoadedWorkspaces(mod.ID); err != nil {
 				return nil, err
 			}
 			return ReloadSummary{Added: added, Removed: removed}, nil

--- a/internal/workspace/reloader_test.go
+++ b/internal/workspace/reloader_test.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/leg100/pug/internal"
 	"github.com/leg100/pug/internal/module"
 	"github.com/leg100/pug/internal/resource"
 	"github.com/stretchr/testify/assert"
@@ -30,7 +29,7 @@ func TestWorkspace_parseList(t *testing.T) {
 }
 
 func TestWorkspace_resetWorkspaces(t *testing.T) {
-	mod := module.New(internal.NewTestWorkdir(t), module.Options{Path: "a/b/c"})
+	mod := &module.Module{Path: "a/b/c"}
 	dev, err := New(mod, "dev")
 	require.NoError(t, err)
 	staging, err := New(mod, "staging")

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/leg100/pug/internal"
 	"github.com/leg100/pug/internal/module"
 	"github.com/leg100/pug/internal/resource"
 )
@@ -51,10 +52,10 @@ func (ws *Workspace) LogValue() slog.Value {
 
 // VarsFile returns the filename of the workspace's terraform variables file
 // and whether it exists or not.
-func (ws *Workspace) VarsFile() (string, bool) {
+func (ws *Workspace) VarsFile(workdir internal.Workdir) (string, bool) {
 	fname := fmt.Sprintf("%s.tfvars", ws.Name)
 	mod := ws.Module().(*module.Module)
-	path := filepath.Join(mod.FullPath(), fname)
+	path := filepath.Join(workdir.String(), mod.Path, fname)
 	_, err := os.Stat(path)
 	return fname, err == nil
 }

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -12,24 +12,25 @@ import (
 )
 
 func TestWorkspace_TerraformEnv(t *testing.T) {
-	mod := module.New(internal.NewTestWorkdir(t), module.Options{Path: "a/b/c"})
-	ws, err := New(mod, "dev")
+	ws, err := New(&module.Module{}, "dev")
 	require.NoError(t, err)
 
 	assert.Equal(t, "TF_WORKSPACE=dev", ws.TerraformEnv())
 }
 
 func TestWorkspace_VarsFile(t *testing.T) {
-	mod := module.New(internal.NewTestWorkdir(t), module.Options{Path: "a/b/c"})
+	workdir := internal.NewTestWorkdir(t)
+	mod := module.NewTestModule(t, module.Options{Path: "a/b/c"})
 	ws, err := New(mod, "dev")
 	require.NoError(t, err)
 
 	// Create a workspace tfvars file for dev
-	os.MkdirAll(mod.FullPath(), 0o755)
-	_, err = os.Create(filepath.Join(mod.FullPath(), "dev.tfvars"))
+	path := workdir.Join(mod.Path, "dev.tfvars")
+	os.MkdirAll(filepath.Dir(path), 0o755)
+	_, err = os.Create(path)
 	require.NoError(t, err)
 
-	got, ok := ws.VarsFile()
+	got, ok := ws.VarsFile(workdir)
 	require.True(t, ok)
 	assert.Equal(t, "dev.tfvars", got)
 }


### PR DESCRIPTION
Alters the workspace loading behaviour. Previously `workspace list` would be the only method via which workspaces are loaded into Pug. Now, the a module will always have at least a `default` workspace, which is always the case with terraform. Also, the module's `.terraform/environment` is inspected to check the current workspace. If that specifies a non-default workspace, then that too is loaded into Pug.