### PR TITLE
fix: resolve performance issues

### DIFF
--- a/internal/pubsub/broker.go
+++ b/internal/pubsub/broker.go
@@ -7,7 +7,7 @@ import (
 	"github.com/leg100/pug/internal/resource"
 )
 
-const bufferSize = 1024
+const bufferSize = 1024 * 1024
 
 type Logger interface {
 	Debug(msg string, args ...any)

--- a/internal/tui/border.go
+++ b/internal/tui/border.go
@@ -90,8 +90,8 @@ func borderize(content string, active bool, embeddedText map[BorderPosition]stri
 		// Add the corners
 		return style.Render(leftCorner) + s + style.Render(rightCorner)
 	}
-	// Stack top border onto remaining borders
-	return lipgloss.JoinVertical(lipgloss.Top,
+	// Stack top border, content and horizontal borders, and bottom border.
+	return strings.Join([]string{
 		buildHorizontalBorder(
 			embeddedText[TopLeftBorder],
 			embeddedText[TopMiddleBorder],
@@ -111,5 +111,5 @@ func borderize(content string, active bool, embeddedText map[BorderPosition]stri
 			border.Bottom,
 			border.BottomRight,
 		),
-	)
+	}, "\n")
 }

--- a/internal/tui/explorer/messages.go
+++ b/internal/tui/explorer/messages.go
@@ -1,3 +1,6 @@
 package explorer
 
-type builtTreeMsg *tree
+type builtTreeMsg struct {
+	tree     *tree
+	rendered string
+}

--- a/internal/tui/explorer/nodes.go
+++ b/internal/tui/explorer/nodes.go
@@ -11,9 +11,10 @@ import (
 
 type node interface {
 	fmt.Stringer
-
 	// ID uniquely identifies the node
 	ID() any
+	// Value returns a value for lexicographic sorting
+	Value() string
 }
 
 type dirNode struct {
@@ -26,12 +27,16 @@ func (d dirNode) ID() any {
 	return d.path
 }
 
-func (d dirNode) String() string {
+func (d dirNode) Value() string {
 	if d.root {
-		return fmt.Sprintf("%s %s", tui.DirIcon, d.path)
+		return d.path
 	} else {
-		return fmt.Sprintf("%s %s", tui.DirIcon, filepath.Base(d.path))
+		return filepath.Base(d.path)
 	}
+}
+
+func (d dirNode) String() string {
+	return fmt.Sprintf("%s %s", tui.DirIcon, d.Value())
 }
 
 type moduleNode struct {
@@ -43,8 +48,12 @@ func (m moduleNode) ID() any {
 	return m.id
 }
 
+func (m moduleNode) Value() string {
+	return filepath.Base(m.path)
+}
+
 func (m moduleNode) String() string {
-	return tui.ModulePathWithIcon(filepath.Base(m.path), false)
+	return tui.ModulePathWithIcon(m.Value(), false)
 }
 
 type workspaceNode struct {
@@ -57,6 +66,10 @@ type workspaceNode struct {
 
 func (w workspaceNode) ID() any {
 	return w.id
+}
+
+func (w workspaceNode) Value() string {
+	return w.name
 }
 
 func (w workspaceNode) String() string {

--- a/internal/tui/top/model.go
+++ b/internal/tui/top/model.go
@@ -361,7 +361,7 @@ func (m model) View() string {
 		Width(m.width).
 		Render(footer),
 	)
-	return lipgloss.JoinVertical(lipgloss.Top, components...)
+	return strings.Join(components, "\n")
 }
 
 var (

--- a/internal/tui/top/start.go
+++ b/internal/tui/top/start.go
@@ -18,7 +18,9 @@ func Start(cfg app.Config) error {
 	if err != nil {
 		return err
 	}
-	defer app.Cleanup()
+	defer func() {
+		app.Cleanup()
+	}()
 
 	m, err := newModel(cfg, app)
 	if err != nil {

--- a/internal/tui/workspace/resource.go
+++ b/internal/tui/workspace/resource.go
@@ -125,19 +125,17 @@ func (m *resourceModel) View() string {
 }
 
 func (m *resourceModel) BorderText() map[tui.BorderPosition]string {
-	var tainted string
+	topLeft := fmt.Sprintf("%s %s",
+		tui.Bold.Render("resource"),
+		m.resource,
+	)
 	if m.resource.Tainted {
-		tainted = lipgloss.NewStyle().
+		topLeft += lipgloss.NewStyle().
 			Foreground(tui.Red).
-			Render("(tainted)")
+			Render(" (tainted)")
 	}
 	return map[tui.BorderPosition]string{
-		tui.TopLeftBorder: fmt.Sprintf(
-			"%s %s %s",
-			tui.Bold.Render("resource"),
-			m.resource,
-			tainted,
-		),
+		tui.TopLeftBorder: topLeft,
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
+	"runtime/pprof"
 
 	"github.com/leg100/pug/internal/app"
 	"github.com/leg100/pug/internal/tui/top"
@@ -10,6 +12,13 @@ import (
 )
 
 func main() {
+	f, err := os.Create("cpu.prof")
+	if err != nil {
+		log.Fatal(err)
+	}
+	pprof.StartCPUProfile(f)
+	defer pprof.StopCPUProfile()
+
 	if err := run(); err != nil {
 		fmt.Println(err.Error())
 		os.Exit(1)


### PR DESCRIPTION
When handling 100s or 1000s of modules some performance issues became evident. This PR fixes those issues.

* prevent concurrent re-building of the explorer tree
* move expensive rendering out of View() into bubbletea cmd
* increase event buffer size to resolve deadlock when handling very large numbers of events (this is a hack and the underlying deadlock should really be detected and removed)