### PR TITLE
the --terragrunt-non-interactive flag is deprecated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ pug.log
 go.work
 
 dist/
+
+# for people whose editor generates tags
+*tags*

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ When `terragrunt` is specified as the program executable, Pug enables "terragrun
 
 * Modules are detected via the presence of a `terragrunt.hcl` file. (You may want to rename the top-level `terragrunt.hcl` file to something else otherwise it is mis-detected as a module).
 * Module dependencies are supported. After modules are loaded, a task invokes `terragrunt graph-dependencies`, from which dependencies are parsed and configured in Pug. If you apply multiple modules Pug ensures their dependencies are respected, applying modules in topological order. If you apply a *destroy* plan for multiple modules, modules are applied in reverse topological order.
-* The flag `--terragrunt-non-interactive` is added to commands.
+* The flag `--non-interactive` is added to commands.
 
 ## Multiple terraform versions
 

--- a/hacks/rebuild.sh
+++ b/hacks/rebuild.sh
@@ -2,5 +2,13 @@
 
 while true; do
     go build -o _build/pug && pkill -f '_build/pug'
-    inotifywait -e attrib $(find . -name '*.go') || exit
+
+    # OSX doesn't have inotifywait, so we use fswatch instead
+    if [[ "$(uname)" == "Darwin" ]]; then
+      fswatch -e .git -o $(find . -name '*.go') || exit
+    elif [[ "$(uname)" == "Linux" ]]; then
+      inotifywait -e attrib $(find . -name '*.go') || exit
+    else
+      echo "Unknown OS: $(uname)"
+    fi
 done

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -193,7 +193,7 @@ func (f *factory) newTask(spec Spec) (*Task, error) {
 	// Perhaps use constants for terraform, tofu, and terragrunt.
 	if task.Program == "terragrunt" && f.terragrunt {
 		task.AdditionalEnv = append(task.AdditionalEnv, "TERRAGRUNT_FORWARD_TF_STDOUT=1")
-		task.Args = append(task.Args, "--terragrunt-non-interactive")
+		task.Args = append(task.Args, "--non-interactive")
 	}
 	return task, nil
 }


### PR DESCRIPTION
… annoying debug messages in a terraform/terragrunt run.  the correct flag now is --non-interactive.  Also updated the .gitignore to ignore tags files that certain editor setups might create.  Also updated the hacks/rebuild.sh script to work on osx for those of us stuck with osx for work.  osx doesn't have inotifywait so I made the script detect if osx or linux and if osx use fswatch instead